### PR TITLE
Avoid to incorrectly unref a null GstBuffer

### DIFF
--- a/configure
+++ b/configure
@@ -49,6 +49,10 @@ apt-get source "$SOURCE_NAME"
 
 cd ./"$SOURCE_NAME"*/
 
+# Quick fix to diable an error that gstopenh264dec raises when starting to decode about trying to handle and unref a null frame
+# This patch is tied to GStreamer 1.14.5, different versions may need different patch
+patch -R ./ext/openh264/gstopenh264dec.cpp ../gstreamer_1.14.5_gstopenh264dec.cpp.diff
+
 # Inspect the 'configure.ac' file to obtain the names of all plugins that
 # can be enabled or disabled with '--enable-*' and '--disable-*' flags.
 NAMES="$(sed -rn 's/^AG_GST_CHECK_FEATURE\((\w+),.*$/\L\1/p' configure.ac)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+openh264-gst-plugin (1.0.0-0kurento1.18.04~20210614162614.gbp92ba0d) UNRELEASED; urgency=medium
+
+  ** SNAPSHOT build @92ba0dbc033b4388707aca8fe53b20150a241004 **
+
+  [ Juan Navarro ]
+  * Adjust path to install file
+  * Add debian/README.kurento
+  * debian/control: Minor change: Single-line summary
+  * debian: Minor: Delete example files, update Copyright to 2020
+
+  [ root ]
+  * UNRELEASED
+  * UNRELEASED
+  * UNRELEASED
+
+ -- Saul Labajo <slabajo@naevatec.com>  Mon, 14 Jun 2021 16:26:32 +0000
+
 openh264-gst-plugin (1.0.0-0kurento1) unstable; urgency=medium
 
   * Initial Release.

--- a/gstreamer_1.14.5_gstopenh264dec.cpp.diff
+++ b/gstreamer_1.14.5_gstopenh264dec.cpp.diff
@@ -1,0 +1,5 @@
+256,257c256
+<     if (frame)
+< 	gst_video_codec_frame_unref (frame);
+---
+>     gst_video_codec_frame_unref (frame);


### PR DESCRIPTION
<!--
Thank you for your contribution to the Kurento project.
Please provide enough information so that others can review your Pull Request.

For more information, see the Contribution Guidelines:
https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md
-->


## What is the current behavior you want to change?
No new behaviour just fix an incorrect behaviour. When openh264 enconder is instantiated, first time is passed a null GstBuffer that the enconder tries to unref at the end of the handle_frame function, thus causing an incorrect ERROR that in some cases like kurento  test suite may cause the test to fail.Probably the change should be also PR'ed into original GStreamaer repo.


## What is the new behavior provided by this change?
Just avoided to incorrectly unref a null GstBuffer

## How has this been tested?
Compiled, run unit tests and done final manual tests wiuth kurento tutorials

## Types of changes
<!--
What types of changes does your code introduce?
Put an 'x' in all the boxes that apply:
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
<!--
Go over all the following points, and put an 'x' in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [X] I have added an explanation of what the changes do and why they should be included
- [ ] I have written new tests for the changes, as applicable, and have successfully run them locally
